### PR TITLE
[SB-19] Gradle Kotlin convention plugin 적용

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.jetbrains.kotlin.android)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.compose.compiler)
 }
 
 android {
@@ -10,7 +11,7 @@ android {
     defaultConfig {
         applicationId = "co.kr.hoyaho.subway"
         minSdk = 27
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
 
@@ -52,18 +53,17 @@ android {
 dependencies {
 
     implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.ui)
-    implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.ui.tooling.preview)
-    implementation(libs.androidx.material3)
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.ui.graphics)
+    implementation(libs.androidx.compose.ui.tooling.preview)
+    implementation(libs.androidx.compose.material3)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))
-    androidTestImplementation(libs.androidx.ui.test.junit4)
-    debugImplementation(libs.androidx.ui.tooling)
-    debugImplementation(libs.androidx.ui.test.manifest)
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+    debugImplementation(libs.androidx.compose.ui.tooling)
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,48 +1,19 @@
 plugins {
-    alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.compose.compiler)
+    id("subway.android.application")
+    id("subway.android.compose")
 }
 
 android {
     namespace = "co.kr.hoyaho.subway"
-    compileSdk = 35
 
     defaultConfig {
-        applicationId = "co.kr.hoyaho.subway"
-        minSdk = 27
         targetSdk = 35
         versionCode = 1
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        vectorDrawables {
-            useSupportLibrary = true
-        }
     }
 
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-    buildFeatures {
-        compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.1"
-    }
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
@@ -51,19 +22,5 @@ android {
 }
 
 dependencies {
-
-    implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.activity.compose)
-    implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.compose.ui)
-    implementation(libs.androidx.compose.ui.graphics)
-    implementation(libs.androidx.compose.ui.tooling.preview)
-    implementation(libs.androidx.compose.material3)
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
-    androidTestImplementation(platform(libs.androidx.compose.bom))
-    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
-    debugImplementation(libs.androidx.compose.ui.tooling)
-    debugImplementation(libs.androidx.compose.ui.test.manifest)
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    `kotlin-dsl`
+    `kotlin-dsl-precompiled-script-plugins`
+}
+
+dependencies {
+    implementation(libs.android.gradlePlugin)
+    implementation(libs.kotlin.gradlePlugin)
+    compileOnly(libs.compose.compiler.gradle.plugin)
+}

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -8,3 +8,16 @@ dependencies {
     implementation(libs.kotlin.gradlePlugin)
     compileOnly(libs.compose.compiler.gradle.plugin)
 }
+
+gradlePlugin {
+    plugins {
+        register("androidHilt") {
+            id = "subway.android.hilt"
+            implementationClass = "co.kr.hoyahozz.subway.HiltAndroidPlugin"
+        }
+        register("kotlinHilt") {
+            id = "subway.kotlin.hilt"
+            implementationClass = "co.kr.hoyahozz.subway.HiltKotlinPlugin"
+        }
+    }
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,13 @@
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+@Suppress("UnstableApiUsage")
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/co/kr/hoyahozz/subway/AppNameExtension.kt
+++ b/build-logic/src/main/kotlin/co/kr/hoyahozz/subway/AppNameExtension.kt
@@ -1,0 +1,9 @@
+package co.kr.hoyahozz.subway
+
+import org.gradle.api.Project
+
+fun Project.setNamespace(name: String) {
+    androidExtension.apply {
+        namespace = "co.kr.hoyaho.subway.$name"
+    }
+}

--- a/build-logic/src/main/kotlin/co/kr/hoyahozz/subway/ComposeAndroid.kt
+++ b/build-logic/src/main/kotlin/co/kr/hoyahozz/subway/ComposeAndroid.kt
@@ -1,0 +1,35 @@
+package co.kr.hoyahozz.subway
+
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getByType
+import org.jetbrains.kotlin.compose.compiler.gradle.ComposeCompilerGradlePluginExtension
+
+internal fun Project.configureComposeAndroid() {
+    with(plugins) {
+        apply("org.jetbrains.kotlin.plugin.compose")
+    }
+
+    val libs = extensions.libs
+    androidExtension.apply {
+        dependencies {
+            val bom = libs.findLibrary("androidx-compose-bom").get()
+            add("implementation", platform(bom))
+            add("androidTestImplementation", platform(bom))
+
+            add("implementation", libs.findLibrary("androidx.compose.material3").get())
+            add("implementation", libs.findLibrary("androidx.compose.ui").get())
+            add("implementation", libs.findLibrary("androidx.compose.ui.tooling.preview").get())
+            add("androidTestImplementation", libs.findLibrary("androidx.junit").get())
+            add("androidTestImplementation", libs.findLibrary("androidx.espresso.core").get())
+            add("androidTestImplementation", libs.findLibrary("androidx.compose.ui.test.junit4").get())
+            add("debugImplementation", libs.findLibrary("androidx.compose.ui.tooling").get())
+            add("debugImplementation", libs.findLibrary("androidx.compose.ui.test.manifest").get())
+        }
+    }
+
+    extensions.getByType<ComposeCompilerGradlePluginExtension>().apply {
+        enableStrongSkippingMode.set(true)
+        includeSourceInformation.set(true)
+    }
+}

--- a/build-logic/src/main/kotlin/co/kr/hoyahozz/subway/CoroutineAndroid.kt
+++ b/build-logic/src/main/kotlin/co/kr/hoyahozz/subway/CoroutineAndroid.kt
@@ -1,0 +1,19 @@
+package co.kr.hoyahozz.subway
+
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
+
+internal fun Project.configureCoroutineAndroid() {
+    val libs = extensions.libs
+    configureCoroutineKotlin()
+    dependencies {
+        "implementation"(libs.findLibrary("coroutines.android").get())
+    }
+}
+
+internal fun Project.configureCoroutineKotlin() {
+    val libs = extensions.libs
+    dependencies {
+        "implementation"(libs.findLibrary("coroutines.core").get())
+    }
+}

--- a/build-logic/src/main/kotlin/co/kr/hoyahozz/subway/Extension.kt
+++ b/build-logic/src/main/kotlin/co/kr/hoyahozz/subway/Extension.kt
@@ -1,0 +1,26 @@
+package co.kr.hoyahozz.subway
+
+import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.dsl.CommonExtension
+import com.android.build.api.dsl.LibraryExtension
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalog
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.api.plugins.ExtensionContainer
+import org.gradle.kotlin.dsl.getByType
+
+internal val Project.applicationExtension: CommonExtension<*, *, *, *, *, *>
+    get() = extensions.getByType<ApplicationExtension>()
+
+internal val Project.libraryExtension: CommonExtension<*, *, *, *, *, *>
+    get() = extensions.getByType<LibraryExtension>()
+
+internal val Project.androidExtension: CommonExtension<*, *, *, *, *, *>
+    get() = runCatching { libraryExtension }
+        .recoverCatching { applicationExtension }
+        .onFailure { println("Could not find Library or Application extension from this project") }
+        .getOrThrow()
+
+internal val ExtensionContainer.libs: VersionCatalog
+    get() = getByType<VersionCatalogsExtension>().named("libs")
+

--- a/build-logic/src/main/kotlin/co/kr/hoyahozz/subway/HiltAndroid.kt
+++ b/build-logic/src/main/kotlin/co/kr/hoyahozz/subway/HiltAndroid.kt
@@ -1,0 +1,28 @@
+package co.kr.hoyahozz.subway
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
+
+internal fun Project.configureHiltAndroid() {
+    with(pluginManager) {
+        apply("dagger.hilt.android.plugin")
+        apply("com.google.devtools.ksp")
+    }
+
+    val libs = extensions.libs
+    dependencies {
+        "implementation"(libs.findLibrary("hilt.android").get())
+        "ksp"(libs.findLibrary("hilt.android.compiler").get())
+        "kspAndroidTest"(libs.findLibrary("hilt.android.compiler").get())
+    }
+}
+
+internal class HiltAndroidPlugin : Plugin<Project> {
+
+    override fun apply(target: Project) {
+        with(target) {
+            configureHiltAndroid()
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/co/kr/hoyahozz/subway/HiltKotlin.kt
+++ b/build-logic/src/main/kotlin/co/kr/hoyahozz/subway/HiltKotlin.kt
@@ -1,0 +1,26 @@
+package co.kr.hoyahozz.subway
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
+
+internal fun Project.configureHiltKotlin() {
+    with(pluginManager) {
+        apply("com.google.devtools.ksp")
+    }
+
+    val libs = extensions.libs
+    dependencies {
+        "implementation"(libs.findLibrary("hilt.core").get())
+        "ksp"(libs.findLibrary("hilt.compiler").get())
+    }
+}
+
+internal class HiltKotlinPlugin : Plugin<Project> {
+
+    override fun apply(target: Project) {
+        with(target) {
+            configureHiltKotlin()
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/co/kr/hoyahozz/subway/KotlinAndroid.kt
+++ b/build-logic/src/main/kotlin/co/kr/hoyahozz/subway/KotlinAndroid.kt
@@ -1,0 +1,70 @@
+package co.kr.hoyahozz.subway
+
+import org.gradle.api.JavaVersion
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.provideDelegate
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+
+// https://github.com/android/nowinandroid/blob/main/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/KotlinAndroid.kt
+internal fun Project.configureKotlinAndroid() {
+    // Plugins
+    pluginManager.apply("org.jetbrains.kotlin.android")
+
+    // Android settings
+    androidExtension.apply {
+        compileSdk = 35
+
+        defaultConfig {
+            minSdk = 27
+        }
+
+        compileOptions {
+            sourceCompatibility = JavaVersion.VERSION_17
+            targetCompatibility = JavaVersion.VERSION_17
+            isCoreLibraryDesugaringEnabled = true
+        }
+
+        buildTypes {
+            getByName("debug") {
+                isMinifyEnabled = false
+            }
+
+            getByName("release") {
+                isMinifyEnabled = true
+                proguardFiles(
+                    getDefaultProguardFile("proguard-android-optimize.txt"),
+                    "proguard-rules.pro"
+                )
+            }
+        }
+    }
+
+    configureKotlin()
+
+    val libs = extensions.libs
+
+    dependencies {
+        add("coreLibraryDesugaring", libs.findLibrary("android.desugarJdkLibs").get())
+    }
+}
+
+internal fun Project.configureKotlin() {
+    tasks.withType<KotlinCompile>().configureEach {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+            // Treat all Kotlin warnings as errors (disabled by default)
+            // Override by setting warningsAsErrors=true in your ~/.gradle/gradle.properties
+            val warningsAsErrors: String? by project
+            allWarningsAsErrors.set(warningsAsErrors.toBoolean())
+            freeCompilerArgs.set(
+                freeCompilerArgs.get() + listOf(
+                    "-opt-in=kotlin.RequiresOptIn",
+                )
+            )
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/co/kr/hoyahozz/subway/TestKotlin.kt
+++ b/build-logic/src/main/kotlin/co/kr/hoyahozz/subway/TestKotlin.kt
@@ -1,0 +1,20 @@
+package co.kr.hoyahozz.subway
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.testing.Test
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.withType
+
+internal fun Project.configureTest() {
+    configureJUnit()
+    val libs = extensions.libs
+    dependencies {
+        "testImplementation"(libs.findLibrary("junit").get())
+    }
+}
+
+internal fun Project.configureJUnit() {
+    tasks.withType<Test>().configureEach {
+        useJUnitPlatform()
+    }
+}

--- a/build-logic/src/main/kotlin/subway.android.application.gradle.kts
+++ b/build-logic/src/main/kotlin/subway.android.application.gradle.kts
@@ -1,0 +1,9 @@
+import co.kr.hoyahozz.subway.configureHiltAndroid
+import co.kr.hoyahozz.subway.configureKotlinAndroid
+
+plugins {
+    id("com.android.application")
+}
+
+configureKotlinAndroid()
+configureHiltAndroid()

--- a/build-logic/src/main/kotlin/subway.android.application.gradle.kts
+++ b/build-logic/src/main/kotlin/subway.android.application.gradle.kts
@@ -1,5 +1,6 @@
 import co.kr.hoyahozz.subway.configureHiltAndroid
 import co.kr.hoyahozz.subway.configureKotlinAndroid
+import co.kr.hoyahozz.subway.configureTest
 
 plugins {
     id("com.android.application")
@@ -7,3 +8,4 @@ plugins {
 
 configureKotlinAndroid()
 configureHiltAndroid()
+configureTest()

--- a/build-logic/src/main/kotlin/subway.android.compose.gradle.kts
+++ b/build-logic/src/main/kotlin/subway.android.compose.gradle.kts
@@ -1,0 +1,3 @@
+import co.kr.hoyahozz.subway.configureComposeAndroid
+
+configureComposeAndroid()

--- a/build-logic/src/main/kotlin/subway.android.feature.gradle.kts
+++ b/build-logic/src/main/kotlin/subway.android.feature.gradle.kts
@@ -1,0 +1,23 @@
+import co.kr.hoyahozz.subway.configureHiltAndroid
+import co.kr.hoyahozz.subway.libs
+
+plugins {
+    id("subway.android.library")
+    id("subway.android.compose")
+}
+
+android {
+    defaultConfig {
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+}
+configureHiltAndroid()
+
+dependencies {
+    val libs = project.extensions.libs
+    implementation(libs.findLibrary("hilt.navigation.compose").get())
+    implementation(libs.findLibrary("androidx.compose.navigation").get())
+
+    implementation(libs.findLibrary("androidx.lifecycle.viewModelCompose").get())
+    implementation(libs.findLibrary("androidx.lifecycle.runtimeCompose").get())
+}

--- a/build-logic/src/main/kotlin/subway.android.library.gradle.kts
+++ b/build-logic/src/main/kotlin/subway.android.library.gradle.kts
@@ -1,6 +1,7 @@
 import co.kr.hoyahozz.subway.configureCoroutineAndroid
 import co.kr.hoyahozz.subway.configureHiltAndroid
 import co.kr.hoyahozz.subway.configureKotlinAndroid
+import co.kr.hoyahozz.subway.configureTest
 
 plugins {
     id("com.android.library")
@@ -9,3 +10,4 @@ plugins {
 configureKotlinAndroid()
 configureCoroutineAndroid()
 configureHiltAndroid()
+configureTest()

--- a/build-logic/src/main/kotlin/subway.android.library.gradle.kts
+++ b/build-logic/src/main/kotlin/subway.android.library.gradle.kts
@@ -1,0 +1,11 @@
+import co.kr.hoyahozz.subway.configureCoroutineAndroid
+import co.kr.hoyahozz.subway.configureHiltAndroid
+import co.kr.hoyahozz.subway.configureKotlinAndroid
+
+plugins {
+    id("com.android.library")
+}
+
+configureKotlinAndroid()
+configureCoroutineAndroid()
+configureHiltAndroid()

--- a/build-logic/src/main/kotlin/subway.kotlin.library.gradle.kts
+++ b/build-logic/src/main/kotlin/subway.kotlin.library.gradle.kts
@@ -1,7 +1,9 @@
 import co.kr.hoyahozz.subway.configureKotlin
+import co.kr.hoyahozz.subway.configureTest
 
 plugins {
     kotlin("jvm")
 }
 
 configureKotlin()
+configureTest()

--- a/build-logic/src/main/kotlin/subway.kotlin.library.gradle.kts
+++ b/build-logic/src/main/kotlin/subway.kotlin.library.gradle.kts
@@ -1,0 +1,7 @@
+import co.kr.hoyahozz.subway.configureKotlin
+
+plugins {
+    kotlin("jvm")
+}
+
+configureKotlin()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,17 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.jetbrains.kotlin.android) apply false
     alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.jetbrains.kotlin.jvm) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.kotlin.jvm) apply false
+    alias(libs.plugins.compose.compiler) apply false
+    alias(libs.plugins.hilt) apply false
+    alias(libs.plugins.ksp) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,38 +1,94 @@
 [versions]
+## Android gradle plugin
 agp = "8.5.2"
-kotlin = "1.9.0"
-coreKtx = "1.15.0"
+
+## Desugaring
+androidDesugarJdkLibs = "2.1.4"
+
+## Kotlin Symbol Processing
+ksp = "2.0.0-1.0.22"
+
+## AndoridX
+androidxCore = "1.15.0"
+androidxLifecycle = "2.8.7"
+activityCompose = "1.9.3"
+androidxComposeBom = "2024.12.01"
+androidxAppcompat = "1.7.0"
+androidxMaterial3 = "1.3.1"
+androidxComposeNavigation = "2.8.5"
+
+## Network
+okhttp = "4.12.0"
+retrofit = "2.11.0"
+
+## Kotlin
+kotlin = "2.0.0"
+kotlinxSerializationJson = "1.7.0"
+kotlinxImmutable = "0.3.7"
+coroutine = "1.9.0"
+
+## Hilt
+hilt = "2.51.1"
+hiltNavigationCompose = "1.2.0"
+
+## Test
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
-lifecycleRuntimeKtx = "2.8.7"
-activityCompose = "1.9.3"
-composeBom = "2024.04.01"
-appcompat = "1.7.0"
-material = "1.12.0"
-jetbrainsKotlinJvm = "1.9.0"
+
 
 [libraries]
-androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
-junit = { group = "junit", name = "junit", version.ref = "junit" }
+android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
+android-desugarJdkLibs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "androidDesugarJdkLibs" }
+kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCore" }
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppcompat" }
+androidx-lifecycle-runtimeCompose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidxLifecycle" }
+androidx-lifecycle-viewModelCompose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "androidxLifecycle" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+compose-compiler-gradle-plugin = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
+
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
-androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
-androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
-androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
-androidx-ui = { group = "androidx.compose.ui", name = "ui" }
-androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
-androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
-androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
-androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
-androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
-androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
-androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "androidxMaterial3" }
+androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
+androidx-compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
+androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+androidx-compose-navigation = { group = "androidx.navigation", name = "navigation-compose", version.ref = "androidxComposeNavigation" }
+androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
+androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+
+okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
+retrofit-core = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
+retrofit-kotlin-serialization = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofit" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+kotlinx-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinxImmutable" }
+
+coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutine" }
+coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutine" }
+
+hilt-core = { group = "com.google.dagger", name = "hilt-core", version.ref = "hilt" }
+hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
+
+hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
+hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt" }
+hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
+
+hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+
+junit = { group = "junit", name = "junit", version.ref = "junit" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "agp" }
-jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "jetbrainsKotlinJvm" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,5 @@
 pluginManagement {
+    includeBuild("build-logic")
     repositories {
         google {
             content {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,7 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+@Suppress("UnstableApiUsage")
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
@@ -23,5 +24,9 @@ rootProject.name = "Subway"
 include(":app")
 include(":data")
 include(":domain")
-include(":feature:home")
-include(":feature:detail")
+
+// Feature
+include(
+    ":feature:home",
+    ":feature:detail"
+)


### PR DESCRIPTION
## 작업 내용

- closes #10 

</br>

- 멀티 모듈을 활용할 경우, 모듈을 만들 때마다 build.gradle 내 중복 코드가 발생합니다.
- **반복되는 빌드 로직을 재사용하기 위해, `Gradle Kotlin convention plugin` 을 적용**하였습니다.
   - `Plugin` 에는 `Script plugin`, `Binary plugin`, `Precompiled plugin` 이 있습니다.
   - 그 중 [드로이드나이츠 2023 레포](https://github.com/droidknights/DroidKnightsApp)에 적용된 **`Precompiled Plugin` 을 사용**해보았습니다!

## 실행 화면

- 단순 세팅이므로 미첨부합니다.


## 리뷰 요청 사항

- 대충 반복되는 모듈 코드를 요렇게 관리하는구나.. 정도로만 알고 넘어가도 될 것 같아요!


## 레퍼런스

- [Plugin이란 무엇인가? 플러그인 이해하고 Custom Plugin 만들기](https://kotlinworld.com/323)
- [[DroidKnights 2023] - Gradle Kotlin 컨벤션 플러그인으로 효율적으로 멀티 모듈 관리하기](https://www.youtube.com/watch?v=7iag6zpGd98)
- [Gradle 공식 문서](https://docs.gradle.org/current/userguide/custom_plugins.html#sec:precompile_script_plugin)