### PR TITLE
[SB-39] 상세 화면 구현

### DIFF
--- a/core/navigation/src/main/java/co/kr/hoyaho/navigation/RouteModel.kt
+++ b/core/navigation/src/main/java/co/kr/hoyaho/navigation/RouteModel.kt
@@ -4,6 +4,9 @@ import kotlinx.serialization.Serializable
 
 sealed interface Route {
     @Serializable
+    data object HomeBase : Route
+
+    @Serializable
     data object Home : Route
 
     @Serializable

--- a/core/navigation/src/main/java/co/kr/hoyaho/navigation/RouteModel.kt
+++ b/core/navigation/src/main/java/co/kr/hoyaho/navigation/RouteModel.kt
@@ -7,5 +7,8 @@ sealed interface Route {
     data object Home : Route
 
     @Serializable
-    data object Detail : Route
+    data class Detail(
+        val lineNumber: String,
+        val stationName: String,
+    ) : Route
 }

--- a/data/src/main/java/co/kr/hoyaho/data/model/StationPassengerStatsResponse.kt
+++ b/data/src/main/java/co/kr/hoyaho/data/model/StationPassengerStatsResponse.kt
@@ -1,0 +1,54 @@
+package co.kr.hoyaho.data.model
+
+import co.kr.hoyaho.domain.model.StationPassengerStats
+import co.kr.hoyaho.domain.util.DateFormatter
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class StationPassengerStatsResponse(
+    @SerialName("CardSubwayStatsNew")
+    val result: CardSubwayStatsNew,
+)
+
+@Serializable
+internal data class CardSubwayStatsNew(
+    @SerialName("list_total_count")
+    val listTotalCount: Int,
+    @SerialName("row")
+    val stats: List<PassengerStatsResponse>,
+)
+
+@Serializable
+internal data class PassengerStatsResponse(
+    @SerialName("SBWY_ROUT_LN_NM")
+    val lineNumber: String,
+    @SerialName("SBWY_STNS_NM")
+    val stationName: String,
+    @SerialName("GTOFF_TNOPE")
+    val getOnNumberOfPassenger: Double,
+    @SerialName("GTON_TNOPE")
+    val getOffNumberOfPassenger: Double,
+    @SerialName("REG_YMD")
+    val registerDate: String,
+    @SerialName("USE_YMD")
+    val useDate: String,
+)
+
+internal fun StationPassengerStatsResponse.toDomain(
+    dateFormatter: DateFormatter,
+): List<StationPassengerStats> = result.toDomain(dateFormatter)
+
+internal fun CardSubwayStatsNew.toDomain(
+    dateFormatter: DateFormatter,
+): List<StationPassengerStats> = stats.map { it.toDomain(dateFormatter) }
+
+internal fun PassengerStatsResponse.toDomain(
+    dateFormatter: DateFormatter,
+): StationPassengerStats = StationPassengerStats(
+    lineNumber = this.lineNumber,
+    name = this.stationName,
+    useDate = dateFormatter.parse(this.useDate),
+    boardingCount = getOnNumberOfPassenger.toInt(),
+    alightingCount = getOffNumberOfPassenger.toInt(),
+)

--- a/data/src/main/java/co/kr/hoyaho/data/model/StationPassengerStatsResponse.kt
+++ b/data/src/main/java/co/kr/hoyaho/data/model/StationPassengerStatsResponse.kt
@@ -25,9 +25,9 @@ internal data class PassengerStatsResponse(
     val lineNumber: String,
     @SerialName("SBWY_STNS_NM")
     val stationName: String,
-    @SerialName("GTOFF_TNOPE")
-    val getOnNumberOfPassenger: Double,
     @SerialName("GTON_TNOPE")
+    val getOnNumberOfPassenger: Double,
+    @SerialName("GTOFF_TNOPE")
     val getOffNumberOfPassenger: Double,
     @SerialName("REG_YMD")
     val registerDate: String,

--- a/data/src/main/java/co/kr/hoyaho/data/repository/SubwayRepository.kt
+++ b/data/src/main/java/co/kr/hoyaho/data/repository/SubwayRepository.kt
@@ -4,12 +4,26 @@ import co.kr.hoyaho.data.model.StationsResponse
 import co.kr.hoyaho.data.model.toDomain
 import co.kr.hoyaho.data.source.SubwayDataSource
 import co.kr.hoyaho.domain.model.Station
+import co.kr.hoyaho.domain.model.StationPassengerStats
 import co.kr.hoyaho.domain.repository.SubwayRepository
+import co.kr.hoyaho.domain.util.DateFormatter
 import javax.inject.Inject
 
 internal class SubwayRepositoryImpl @Inject constructor(
     private val subwayDataSource: SubwayDataSource,
+    private val dateFormatter: DateFormatter,
 ) : SubwayRepository {
     override suspend fun getStations(): Result<List<Station>> =
         subwayDataSource.getStations().map(StationsResponse::toDomain)
+
+    override suspend fun getRecentStationPassengerStats(
+        lineNumber: String,
+        stationName: String,
+    ): Result<StationPassengerStats> =
+        subwayDataSource.getRecentStationPassengerStats(
+            lineNumber = lineNumber,
+            stationName = stationName,
+        )
+            .map { it.toDomain(dateFormatter) }
+            .map { it.first() }
 }

--- a/data/src/main/java/co/kr/hoyaho/data/service/SubwayService.kt
+++ b/data/src/main/java/co/kr/hoyaho/data/service/SubwayService.kt
@@ -1,5 +1,6 @@
 package co.kr.hoyaho.data.service
 
+import co.kr.hoyaho.data.model.StationPassengerStatsResponse
 import co.kr.hoyaho.data.model.StationsResponse
 import retrofit2.http.GET
 import retrofit2.http.Path
@@ -10,4 +11,13 @@ internal interface SubwayService {
         @Path("startIndex") startIndex: Int = 0,
         @Path("endIndex") endIndex: Int = 999,
     ): StationsResponse
+
+    @GET("CardSubwayStatsNew/{startIndex}/{endIndex}/{useYmd}/{sbwyRoutLnNm}/{sbwyStnsNm}")
+    suspend fun getStationPassengerStats(
+        @Path("startIndex") startIndex: Int = 0,
+        @Path("endIndex") endIndex: Int = 999,
+        @Path("useYmd") useDate: String,
+        @Path("sbwyRoutLnNm") lineNumber: String,
+        @Path("sbwyStnsNm") stationName: String,
+    ): StationPassengerStatsResponse
 }

--- a/data/src/main/java/co/kr/hoyaho/data/source/SubwayDataSource.kt
+++ b/data/src/main/java/co/kr/hoyaho/data/source/SubwayDataSource.kt
@@ -1,13 +1,29 @@
 package co.kr.hoyaho.data.source
 
+import co.kr.hoyaho.data.model.StationPassengerStatsResponse
 import co.kr.hoyaho.data.model.StationsResponse
 import co.kr.hoyaho.data.service.SubwayService
+import co.kr.hoyaho.domain.util.DateFormatter
+import java.time.LocalDate
 import javax.inject.Inject
 
 internal class SubwayDataSource @Inject constructor(
     private val subwayService: SubwayService,
+    private val dateFormatter: DateFormatter,
 ) {
     suspend fun getStations(): Result<StationsResponse> = runCatching {
         subwayService.getStations()
+    }
+
+    suspend fun getRecentStationPassengerStats(
+        lineNumber: String,
+        stationName: String,
+    ): Result<StationPassengerStatsResponse> = runCatching {
+        subwayService.getStationPassengerStats(
+            // 서울열린데이터광장에서 제공하는 가장 최신 데이터는 4일전의 데이터이다.
+            useDate = dateFormatter.format(LocalDate.now().minusDays(4)),
+            lineNumber = lineNumber,
+            stationName = stationName,
+        )
     }
 }

--- a/domain/src/main/java/co/kr/hoyaho/domain/model/StationPassengerStats.kt
+++ b/domain/src/main/java/co/kr/hoyaho/domain/model/StationPassengerStats.kt
@@ -1,0 +1,11 @@
+package co.kr.hoyaho.domain.model
+
+import java.time.LocalDate
+
+data class StationPassengerStats(
+    val lineNumber: String,
+    val name: String,
+    val useDate: LocalDate,
+    val boardingCount: Int,
+    val alightingCount: Int,
+)

--- a/domain/src/main/java/co/kr/hoyaho/domain/repository/SubwayRepository.kt
+++ b/domain/src/main/java/co/kr/hoyaho/domain/repository/SubwayRepository.kt
@@ -1,7 +1,12 @@
 package co.kr.hoyaho.domain.repository
 
 import co.kr.hoyaho.domain.model.Station
+import co.kr.hoyaho.domain.model.StationPassengerStats
 
 interface SubwayRepository {
     suspend fun getStations(): Result<List<Station>>
+    suspend fun getRecentStationPassengerStats(
+        lineNumber: String,
+        stationName: String,
+    ): Result<StationPassengerStats>
 }

--- a/domain/src/main/java/co/kr/hoyaho/domain/usecase/GetRecentStationPassengerStatsUseCase.kt
+++ b/domain/src/main/java/co/kr/hoyaho/domain/usecase/GetRecentStationPassengerStatsUseCase.kt
@@ -1,0 +1,18 @@
+package co.kr.hoyaho.domain.usecase
+
+import co.kr.hoyaho.domain.model.StationPassengerStats
+import co.kr.hoyaho.domain.repository.SubwayRepository
+import javax.inject.Inject
+
+class GetRecentStationPassengerStatsUseCase @Inject constructor(
+    private val repository: SubwayRepository,
+) {
+    suspend operator fun invoke(
+        lineNumber: String,
+        stationName: String,
+    ): Result<StationPassengerStats> =
+        repository.getRecentStationPassengerStats(
+            lineNumber = lineNumber,
+            stationName = stationName,
+        )
+}

--- a/domain/src/main/java/co/kr/hoyaho/domain/util/DateFormatter.kt
+++ b/domain/src/main/java/co/kr/hoyaho/domain/util/DateFormatter.kt
@@ -1,0 +1,25 @@
+package co.kr.hoyaho.domain.util
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+
+class DateFormatter @Inject constructor() {
+    fun parse(
+        rawDate: String,
+        formatter: DateTimeFormatter = DATE_FORMAT,
+    ): LocalDate {
+        require(rawDate.isNotBlank())
+
+        return LocalDate.parse(rawDate, formatter)
+    }
+
+    fun format(
+        date: LocalDate,
+        formatter: DateTimeFormatter = DATE_FORMAT,
+    ): String = formatter.format(date)
+
+    companion object {
+        private val DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd")
+    }
+}

--- a/feature/detail/src/main/java/co/kr/hoyaho/detail/DetailContract.kt
+++ b/feature/detail/src/main/java/co/kr/hoyaho/detail/DetailContract.kt
@@ -1,13 +1,24 @@
 package co.kr.hoyaho.detail
 
+import co.kr.hoyaho.domain.model.StationPassengerStats
 import co.kr.hoyaho.ui.base.UiEvent
 import co.kr.hoyaho.ui.base.UiSideEffect
 import co.kr.hoyaho.ui.base.UiState
 
 internal class DetailContract {
-    data object DetailUiState : UiState
+    data class DetailUiState(
+        val loadState: LoadState = LoadState.Loading,
+        val stats: StationPassengerStats? = null,
+    ) : UiState
+
+    enum class LoadState {
+        Loading,
+        Idle,
+    }
 
     data object DetailUiEvent : UiEvent
 
-    data object DetailSideEffect : UiSideEffect
+    sealed interface DetailSideEffect : UiSideEffect {
+        data class ShowToast(val message: String) : DetailSideEffect
+    }
 }

--- a/feature/detail/src/main/java/co/kr/hoyaho/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/co/kr/hoyaho/detail/DetailScreen.kt
@@ -8,11 +8,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
 @Composable
-internal fun DetailScreen(modifier: Modifier = Modifier) {
-    Scaffold(modifier = modifier.fillMaxSize()) { innerPadding ->
+internal fun DetailScreen(
+    lineNumber: String,
+    stationName: String,
+) {
+    Scaffold(modifier = Modifier.fillMaxSize()) { padding ->
         Text(
-            "Detail",
-            modifier = Modifier.padding(innerPadding),
+            "Detail, $lineNumber - $stationName",
+            modifier = Modifier.padding(padding),
         )
     }
 }

--- a/feature/detail/src/main/java/co/kr/hoyaho/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/co/kr/hoyaho/detail/DetailScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -12,11 +13,16 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import co.kr.hoyaho.designsystem.theme.SubwayTheme
 import co.kr.hoyaho.detail.DetailContract.DetailSideEffect
 import co.kr.hoyaho.detail.DetailContract.DetailUiState
+import co.kr.hoyaho.detail.DetailContract.LoadState
 
 @Composable
 internal fun DetailRoute(
@@ -53,18 +59,42 @@ private fun DetailScreen(
     modifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier.fillMaxSize()) {
-        state.stats?.let { stats ->
-            Column(
+        when (state.loadState) {
+            LoadState.Loading -> CircularProgressIndicator(
                 modifier = Modifier.align(Alignment.Center),
-            ) {
-                Text("${stats.lineNumber} ${stats.name}")
-                Text("탑승 인원 : ${stats.boardingCount}")
-                Text("하차 인원 : ${stats.alightingCount}")
-                Text("등록일 : ${stats.useDate}")
-            }
-        } ?: Text(
-            "통계가 존재하지 않습니다.",
-            modifier = Modifier.align(Alignment.Center),
-        )
+            )
+
+            LoadState.Idle -> state.stats?.let { stats ->
+                Column(
+                    modifier = Modifier.align(Alignment.Center),
+                ) {
+                    Text("${stats.lineNumber} ${stats.name}")
+                    Text("탑승 인원 : ${stats.boardingCount}")
+                    Text("하차 인원 : ${stats.alightingCount}")
+                    Text("등록일 : ${stats.useDate}")
+                }
+            } ?: Text(
+                "통계가 존재하지 않습니다.",
+                modifier = Modifier.align(Alignment.Center),
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun DetailScreenPreview(
+    @PreviewParameter(DetailUiStatePreviewParameterProvider::class)
+    state: DetailUiState,
+) {
+    SubwayTheme {
+        Scaffold(
+            containerColor = Color.White,
+        ) { padding ->
+            DetailScreen(
+                state = state,
+                modifier = Modifier.padding(padding),
+            )
+        }
     }
 }

--- a/feature/detail/src/main/java/co/kr/hoyaho/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/co/kr/hoyaho/detail/DetailScreen.kt
@@ -1,21 +1,70 @@
 package co.kr.hoyaho.detail
 
+import android.widget.Toast
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import co.kr.hoyaho.detail.DetailContract.DetailSideEffect
+import co.kr.hoyaho.detail.DetailContract.DetailUiState
 
 @Composable
-internal fun DetailScreen(
+internal fun DetailRoute(
     lineNumber: String,
     stationName: String,
+    viewModel: DetailViewModel = hiltViewModel(),
 ) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
     Scaffold(modifier = Modifier.fillMaxSize()) { padding ->
-        Text(
-            "Detail, $lineNumber - $stationName",
+        DetailScreen(
+            state = uiState,
             modifier = Modifier.padding(padding),
+        )
+    }
+
+    LaunchedEffect(lineNumber, stationName) {
+        viewModel.getRecentStationPassenger(lineNumber, stationName)
+    }
+
+    LaunchedEffect(viewModel.effect) {
+        viewModel.effect.collect { effect ->
+            if (effect is DetailSideEffect.ShowToast) {
+                Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+}
+
+@Composable
+private fun DetailScreen(
+    state: DetailUiState,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier.fillMaxSize()) {
+        state.stats?.let { stats ->
+            Column(
+                modifier = Modifier.align(Alignment.Center),
+            ) {
+                Text("${stats.lineNumber} ${stats.name}")
+                Text("탑승 인원 : ${stats.boardingCount}")
+                Text("하차 인원 : ${stats.alightingCount}")
+                Text("등록일 : ${stats.useDate}")
+            }
+        } ?: Text(
+            "통계가 존재하지 않습니다.",
+            modifier = Modifier.align(Alignment.Center),
         )
     }
 }

--- a/feature/detail/src/main/java/co/kr/hoyaho/detail/DetailViewModel.kt
+++ b/feature/detail/src/main/java/co/kr/hoyaho/detail/DetailViewModel.kt
@@ -1,17 +1,55 @@
 package co.kr.hoyaho.detail
 
+import androidx.lifecycle.viewModelScope
 import co.kr.hoyaho.detail.DetailContract.DetailSideEffect
 import co.kr.hoyaho.detail.DetailContract.DetailUiEvent
 import co.kr.hoyaho.detail.DetailContract.DetailUiState
+import co.kr.hoyaho.detail.DetailContract.LoadState
+import co.kr.hoyaho.domain.usecase.GetRecentStationPassengerStatsUseCase
 import co.kr.hoyaho.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-internal class DetailViewModel @Inject constructor() : BaseViewModel<DetailUiState, DetailUiEvent, DetailSideEffect>(
-    DetailUiState(),
-) {
-    override suspend fun handleEvent(event: DetailUiEvent) {
-        // TODO
+internal class DetailViewModel @Inject constructor(
+    private val getRecentStationPassengerStatsUseCase: GetRecentStationPassengerStatsUseCase,
+) : BaseViewModel<DetailUiState, DetailUiEvent, DetailSideEffect>(DetailUiState()) {
+    override suspend fun handleEvent(event: DetailUiEvent) = Unit
+
+    fun getRecentStationPassenger(
+        lineNumber: String,
+        stationName: String,
+    ) {
+        viewModelScope.launch {
+            getRecentStationPassengerStatsUseCase(
+                lineNumber = getFormatedLineNumber(lineNumber),
+                stationName = stationName,
+            ).fold(
+                onSuccess = { stats ->
+                    updateState {
+                        copy(
+                            loadState = LoadState.Idle,
+                            stats = stats,
+                        )
+                    }
+                },
+                onFailure = { throwable ->
+                    sendEffect(DetailSideEffect.ShowToast(throwable.message ?: "알 수 없는 오류가 발생하였습니다."))
+                },
+            )
+        }
+    }
+
+    /**
+     * 01호선, 02호선 등의 형태로 저장된 문자열에서 1호선, 2호선의 형태로 변경 후 리턴
+     * TODO : enum 형태로 lineNumber 저장 필요
+     */
+    private fun getFormatedLineNumber(lineNumber: String): String {
+        if (lineNumber.first() == '0') {
+            return lineNumber.substring(1..lineNumber.lastIndex)
+        }
+
+        return lineNumber
     }
 }

--- a/feature/detail/src/main/java/co/kr/hoyaho/detail/DetailViewModel.kt
+++ b/feature/detail/src/main/java/co/kr/hoyaho/detail/DetailViewModel.kt
@@ -9,7 +9,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 internal class DetailViewModel @Inject constructor() : BaseViewModel<DetailUiState, DetailUiEvent, DetailSideEffect>(
-    DetailUiState,
+    DetailUiState(),
 ) {
     override suspend fun handleEvent(event: DetailUiEvent) {
         // TODO

--- a/feature/detail/src/main/java/co/kr/hoyaho/detail/HomeUiStatePreviewParameterProvider.kt
+++ b/feature/detail/src/main/java/co/kr/hoyaho/detail/HomeUiStatePreviewParameterProvider.kt
@@ -1,0 +1,29 @@
+package co.kr.hoyaho.detail
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import co.kr.hoyaho.detail.DetailContract.DetailUiState
+import co.kr.hoyaho.detail.DetailContract.LoadState
+import co.kr.hoyaho.domain.model.StationPassengerStats
+import java.time.LocalDate
+
+internal class DetailUiStatePreviewParameterProvider : PreviewParameterProvider<DetailUiState> {
+    override val values: Sequence<DetailUiState> = sequenceOf(
+        DetailUiState(
+            loadState = LoadState.Loading,
+        ),
+        DetailUiState(
+            loadState = LoadState.Idle,
+            stats = null,
+        ),
+        DetailUiState(
+            loadState = LoadState.Idle,
+            stats = StationPassengerStats(
+                lineNumber = "02호선",
+                name = "낙성대",
+                useDate = LocalDate.now(),
+                boardingCount = 3500,
+                alightingCount = 3500,
+            ),
+        ),
+    )
+}

--- a/feature/detail/src/main/java/co/kr/hoyaho/detail/navigation/DetailNavigation.kt
+++ b/feature/detail/src/main/java/co/kr/hoyaho/detail/navigation/DetailNavigation.kt
@@ -5,24 +5,22 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptionsBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
-import co.kr.hoyaho.detail.DetailScreen
+import co.kr.hoyaho.detail.DetailRoute
 import co.kr.hoyaho.navigation.Route
-
-private typealias DetailRoute = Route.Detail
 
 fun NavController.navigateToDetail(
     lineNumber: String,
     stationName: String,
     navOptions: NavOptionsBuilder.() -> Unit = {},
 ) = navigate(
-    route = DetailRoute(lineNumber, stationName),
+    route = Route.Detail(lineNumber, stationName),
     builder = navOptions,
 )
 
 fun NavGraphBuilder.detailScreen() {
-    composable<DetailRoute> { navBackstackEntry ->
-        navBackstackEntry.toRoute<DetailRoute>().apply {
-            DetailScreen(lineNumber, stationName)
+    composable<Route.Detail> { navBackstackEntry ->
+        navBackstackEntry.toRoute<Route.Detail>().apply {
+            DetailRoute(lineNumber, stationName)
         }
     }
 }

--- a/feature/detail/src/main/java/co/kr/hoyaho/detail/navigation/DetailNavigation.kt
+++ b/feature/detail/src/main/java/co/kr/hoyaho/detail/navigation/DetailNavigation.kt
@@ -1,0 +1,28 @@
+package co.kr.hoyaho.detail.navigation
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptionsBuilder
+import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
+import co.kr.hoyaho.detail.DetailScreen
+import co.kr.hoyaho.navigation.Route
+
+private typealias DetailRoute = Route.Detail
+
+fun NavController.navigateToDetail(
+    lineNumber: String,
+    stationName: String,
+    navOptions: NavOptionsBuilder.() -> Unit = {},
+) = navigate(
+    route = DetailRoute(lineNumber, stationName),
+    builder = navOptions,
+)
+
+fun NavGraphBuilder.detailScreen() {
+    composable<DetailRoute> { navBackstackEntry ->
+        navBackstackEntry.toRoute<DetailRoute>().apply {
+            DetailScreen(lineNumber, stationName)
+        }
+    }
+}

--- a/feature/home/src/main/java/co/kr/hoyaho/home/HomeContract.kt
+++ b/feature/home/src/main/java/co/kr/hoyaho/home/HomeContract.kt
@@ -16,9 +16,12 @@ internal class HomeContract {
         Idle,
     }
 
-    data object HomeUiEvent : UiEvent
+    sealed interface HomeUiEvent : UiEvent {
+        data class OnStationClicked(val station: Station) : HomeUiEvent
+    }
 
     sealed interface HomeSideEffect : UiSideEffect {
         data class ShowToast(val message: String) : HomeSideEffect
+        data class NavigateToDetail(val station: Station) : HomeSideEffect
     }
 }

--- a/feature/home/src/main/java/co/kr/hoyaho/home/HomeScreen.kt
+++ b/feature/home/src/main/java/co/kr/hoyaho/home/HomeScreen.kt
@@ -1,10 +1,11 @@
 package co.kr.hoyaho.home
 
 import android.widget.Toast
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -26,12 +27,14 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import co.kr.hoyaho.designsystem.theme.SubwayTheme
 import co.kr.hoyaho.domain.model.Station
 import co.kr.hoyaho.home.HomeContract.HomeSideEffect
+import co.kr.hoyaho.home.HomeContract.HomeUiEvent
 import co.kr.hoyaho.home.HomeContract.HomeUiState
 import co.kr.hoyaho.home.HomeContract.LoadState
 
 @Composable
 internal fun HomeRoute(
     paddingValues: PaddingValues,
+    navigateToDetail: (lineNumber: String, stationName: String) -> Unit,
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -40,13 +43,16 @@ internal fun HomeRoute(
     HomeScreen(
         paddingValues = paddingValues,
         state = uiState,
+        onStationClicked = { station ->
+            viewModel.setEvent(HomeUiEvent.OnStationClicked(station))
+        },
     )
 
     LaunchedEffect(viewModel.effect) {
         viewModel.effect.collect { effect ->
-            if (effect is HomeSideEffect.ShowToast) {
-                // TODO App State 에서 관리하도록 수정
-                Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
+            when (effect) {
+                is HomeSideEffect.ShowToast -> Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
+                is HomeSideEffect.NavigateToDetail -> navigateToDetail(effect.station.lineNumber, effect.station.name)
             }
         }
     }
@@ -56,6 +62,7 @@ internal fun HomeRoute(
 private fun HomeScreen(
     paddingValues: PaddingValues,
     state: HomeUiState,
+    onStationClicked: (Station) -> Unit,
 ) {
     Box(
         modifier = Modifier
@@ -69,6 +76,7 @@ private fun HomeScreen(
 
             LoadState.Idle -> Stations(
                 state.stations,
+                onStationClicked = onStationClicked,
                 modifier = Modifier.fillMaxSize(),
             )
         }
@@ -78,15 +86,21 @@ private fun HomeScreen(
 @Composable
 private fun Stations(
     stations: List<Station>,
+    onStationClicked: (Station) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    LazyColumn(
-        modifier = modifier,
-        contentPadding = PaddingValues(all = 16.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
+    LazyColumn(modifier = modifier) {
         itemsIndexed(stations) { _, station ->
-            Text("[${station.lineNumber}] - ${station.name}")
+            Text(
+                "[${station.lineNumber}] - ${station.name}",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onStationClicked(station) }
+                    .padding(
+                        vertical = 8.dp,
+                        horizontal = 16.dp,
+                    ),
+            )
         }
     }
 }
@@ -104,6 +118,7 @@ private fun HomeScreenPreview(
             HomeScreen(
                 paddingValues = padding,
                 state = homeUiState,
+                onStationClicked = { },
             )
         }
     }

--- a/feature/home/src/main/java/co/kr/hoyaho/home/HomeUiStatePreviewParameterProvider.kt
+++ b/feature/home/src/main/java/co/kr/hoyaho/home/HomeUiStatePreviewParameterProvider.kt
@@ -9,6 +9,9 @@ import kotlinx.collections.immutable.persistentListOf
 internal class HomeUiStatePreviewParameterProvider : PreviewParameterProvider<HomeUiState> {
     override val values: Sequence<HomeUiState> = sequenceOf(
         HomeUiState(
+            loadState = LoadState.Loading,
+        ),
+        HomeUiState(
             loadState = LoadState.Idle,
             stations = persistentListOf(
                 Station(

--- a/feature/home/src/main/java/co/kr/hoyaho/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/co/kr/hoyaho/home/HomeViewModel.kt
@@ -27,7 +27,7 @@ internal class HomeViewModel @Inject constructor(
                     }
                 },
                 onFailure = { throwable ->
-                    sendEffect(HomeSideEffect.ShowToast(throwable.message ?: ""))
+                    sendEffect(HomeSideEffect.ShowToast(throwable.message ?: "알 수 없는 오류가 발생하였습니다."))
                 },
             )
         }

--- a/feature/home/src/main/java/co/kr/hoyaho/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/co/kr/hoyaho/home/HomeViewModel.kt
@@ -34,6 +34,8 @@ internal class HomeViewModel @Inject constructor(
     }
 
     override suspend fun handleEvent(event: HomeUiEvent) {
-        // TODO
+        when (event) {
+            is HomeUiEvent.OnStationClicked -> sendEffect(HomeSideEffect.NavigateToDetail(event.station))
+        }
     }
 }

--- a/feature/home/src/main/java/co/kr/hoyaho/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/co/kr/hoyaho/home/navigation/HomeNavigation.kt
@@ -19,11 +19,12 @@ fun NavController.navigateToHome(navOptions: NavOptions) = navigate(
 
 fun NavGraphBuilder.homeNavGraph(
     padding: PaddingValues,
+    navigateToDetail: (lineNumber: String, stationName: String) -> Unit,
     homeDestination: NavGraphBuilder.() -> Unit,
 ) {
     navigation<HomeBaseRoute>(startDestination = HomeRoute) {
         composable<HomeRoute> {
-            HomeRoute(padding)
+            HomeRoute(padding, navigateToDetail)
         }
     }
     homeDestination()

--- a/feature/home/src/main/java/co/kr/hoyaho/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/co/kr/hoyaho/home/navigation/HomeNavigation.kt
@@ -5,9 +5,11 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.navigation
 import co.kr.hoyaho.home.HomeRoute
 import co.kr.hoyaho.navigation.Route
 
+private typealias HomeBaseRoute = Route.HomeBase
 private typealias HomeRoute = Route.Home
 
 fun NavController.navigateToHome(navOptions: NavOptions) = navigate(
@@ -17,8 +19,12 @@ fun NavController.navigateToHome(navOptions: NavOptions) = navigate(
 
 fun NavGraphBuilder.homeNavGraph(
     padding: PaddingValues,
+    homeDestination: NavGraphBuilder.() -> Unit,
 ) {
-    composable<HomeRoute> {
-        HomeRoute(padding)
+    navigation<HomeBaseRoute>(startDestination = HomeRoute) {
+        composable<HomeRoute> {
+            HomeRoute(padding)
+        }
     }
+    homeDestination()
 }

--- a/feature/main/src/main/java/co/kr/hoyaho/main/navigation/SubwayNavHost.kt
+++ b/feature/main/src/main/java/co/kr/hoyaho/main/navigation/SubwayNavHost.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
+import co.kr.hoyaho.detail.navigation.detailScreen
 import co.kr.hoyaho.home.navigation.homeNavGraph
 import co.kr.hoyaho.main.ui.SubwayAppState
 
@@ -26,7 +27,9 @@ fun SubwayNavHost(
         ) {
             homeNavGraph(
                 padding = paddingValues,
-            )
+            ) {
+                detailScreen()
+            }
         }
     }
 }

--- a/feature/main/src/main/java/co/kr/hoyaho/main/navigation/SubwayNavHost.kt
+++ b/feature/main/src/main/java/co/kr/hoyaho/main/navigation/SubwayNavHost.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import co.kr.hoyaho.detail.navigation.detailScreen
+import co.kr.hoyaho.detail.navigation.navigateToDetail
 import co.kr.hoyaho.home.navigation.homeNavGraph
 import co.kr.hoyaho.main.ui.SubwayAppState
 
@@ -27,6 +28,7 @@ fun SubwayNavHost(
         ) {
             homeNavGraph(
                 padding = paddingValues,
+                navigateToDetail = navController::navigateToDetail,
             ) {
                 detailScreen()
             }

--- a/feature/main/src/main/java/co/kr/hoyaho/main/ui/SubwayAppState.kt
+++ b/feature/main/src/main/java/co/kr/hoyaho/main/ui/SubwayAppState.kt
@@ -25,5 +25,5 @@ class SubwayAppState(
         @Composable get() = navController
             .currentBackStackEntryAsState().value?.destination
 
-    val startDestination = Route.Home
+    val startDestination = Route.HomeBase
 }


### PR DESCRIPTION
## 작업 내용

- Closes #25 

- 상세 화면을 구현하였습니다.
    - 지하철 통계 API 호출 구현
    - 상세 화면 UI 구현 및 API 연동

## 실행 화면

https://github.com/user-attachments/assets/c99b6b59-8987-4dcb-99fa-c6abd8989592


## 리뷰 요청 사항

- 통신 실패했을 때 실패 화면을 따로 만들까 하다가, 미니 프로젝트라서 그냥 넘어갔어요 '-'
- `Circuit` 전환하면서, 성능도 개선시켜볼게요 ~

## 레퍼런스

- NONE
